### PR TITLE
Accept lowercase for issue keys when prompting users

### DIFF
--- a/timetrap_jira_sync.sh
+++ b/timetrap_jira_sync.sh
@@ -125,7 +125,7 @@ prompt_for_issue_key() {
                 ;;
             *)
                 # Validate issue key format
-                if [[ "$input" =~ ^[A-Z]+-[0-9]+$ ]]; then
+                if [[ "$input" =~ ^[A-Za-z]+-[0-9]+$ ]]; then
                     jira_ticket="$input"
                     break
                 else


### PR DESCRIPTION
When parsing worklog notes lowercase is accepted, but when prompting users for input it is not. 

- Ensure consistent case format for allowable Jira issue keys between input methods.

