### PR TITLE
Add short flags single entry

### DIFF
--- a/timetrap_jira_sync.sh
+++ b/timetrap_jira_sync.sh
@@ -25,22 +25,22 @@ NC='\033[0m' # No Color
 # Logging functions
 log_info() {
     if [ "$VERBOSE_MODE" = true ]; then
-        echo -e "${BLUE}[INFO]${NC} $1"
+        echo -e "${BLUE}[INFO]${NC} $1" >&2
     fi
 }
 
 log_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
+    echo -e "${GREEN}[SUCCESS]${NC} $1" >&2
 }
 
 log_warning() {
     if [ "$VERBOSE_MODE" = true ]; then
-        echo -e "${YELLOW}[WARNING]${NC} $1"
+        echo -e "${YELLOW}[WARNING]${NC} $1" >&2
     fi
 }
 
 log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
+    echo -e "${RED}[ERROR]${NC} $1" >&2
 }
 
 # Check if required commands exist
@@ -402,8 +402,7 @@ sync_entries() {
             log_info "Adding worklog: $jira_ticket - $clean_description ($jira_duration) starting at $started_time"
 
             # Add worklog to Jira with timeout
-            log_info "Executing Jira command: timeout 30s $JIRA_CMD issue worklog add \"$jira_ticket\" \"$jira_duration\" --comment=\"$clean_description\" --started=\"$started_time\" --no-input
-"
+            log_info "Executing Jira command: timeout 30s $JIRA_CMD issue worklog add \"$jira_ticket\" \"$jira_duration\" --comment=\"$clean_description\" --started=\"$started_time\" --no-input"
 
             # Execute command and capture output and exit code
             local jira_output


### PR DESCRIPTION
Adds support for passing a single timetrap/tiempo worklog id to the script. 

## Use case: 

After pushing the day's worklogs you realize you need to add one more worklog to Timetrap. Without single worklog support, you'd be duplicating the entire day's worklogs using the script. 

### Documentation Updates

  - Updated help text (-h/--help) to show both short and long flag versions
  - Added new usage examples demonstrating short flag syntax
  - Updated error messages to reference both flag formats
  - Maintained backward compatibility with existing long-form flags

### Testing

  ✅ Verified functionality:
  - Short flags work correctly: ./timetrap_jira_sync.sh -s -i 188 -v
  - Long flags still work: ./timetrap_jira_sync.sh --single-entry --id 188 --verbose
  - Verbose mode now works properly with single entry sync
  - No breaking changes to existing functionality

### Backward Compatibility

  🔄 Fully backward compatible - all existing scripts and usage patterns continue to work unchanged.