### PR TITLE
Added confluence to markdown utility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### confluence-to-md.sh
 
-Reads credentials from the jira-cli config at `~/.config/.jira/.config.yml` (for `login` and `server`) using plain `grep`/`sed` (no yq/python3 needed) and the `JIRA_API_TOKEN` environment variable. Fetches the Confluence REST API (`/wiki/rest/api/content/<PAGE_ID>?expand=body.view,title`) and converts the HTML response to GitHub-flavored Markdown using `pandoc --from html --to gfm-raw_html --wrap none --strip-comments`.
+Reads credentials from the jira-cli config at `~/.config/.jira/.config.yml` (for `login` and `server`) using plain `grep`/`sed` (no yq/python3 needed) and the `JIRA_API_TOKEN` environment variable. Fetches the Confluence REST API (`/wiki/rest/api/content/<PAGE_ID>?expand=body.view,title`) and converts the HTML response to GitHub-flavored Markdown using `pandoc --from html --to gfm+raw_html --wrap none --strip-comments`. The `+raw_html` extension preserves HTML that pandoc cannot convert cleanly (common in Confluence content). Output is written to a temp file and moved into place atomically so a failed conversion never leaves a truncated output file.
 
 ## Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### confluence-to-md.sh
 
-Reads credentials from the jira-cli config at `~/.config/.jira/.config.yml` (for `login` and `server`) using plain `grep`/`sed` (no yq/python3 needed) and the `JIRA_API_TOKEN` environment variable. Fetches the Confluence REST API (`/wiki/rest/api/content/<PAGE_ID>?expand=body.view,title`) and converts the HTML response to GitHub-flavored Markdown using `pandoc --from html --to gfm+raw_html --wrap none --strip-comments`. The `+raw_html` extension preserves HTML that pandoc cannot convert cleanly (common in Confluence content). Output is written to a temp file and moved into place atomically so a failed conversion never leaves a truncated output file.
+Reads credentials from the jira-cli config at `~/.config/.jira/.config.yml` (for `login` and `server`) using plain `grep`/`sed` (no yq/python3 needed) and the `JIRA_API_TOKEN` environment variable. Fetches the Confluence REST API (`/wiki/rest/api/content/<PAGE_ID>?expand=body.view,title`) and converts the HTML response to GitHub-flavored Markdown using `pandoc --from html --to gfm --wrap none --strip-comments`. Output is written to a temp file and moved into place atomically so a failed conversion never leaves a truncated output file.
 
 ## Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `timetrap_jira_sync.sh` | Main script: syncs tiempo-rs time entries to Jira worklogs |
+| `confluence-to-md.sh` | Downloads a Confluence page as Markdown |
+
+## Running the scripts
+
+```bash
+# One-time setup
+./timetrap_jira_sync.sh init
+
+# Common usage
+./timetrap_jira_sync.sh              # Sync today's entries (interactive)
+./timetrap_jira_sync.sh -d YYYY-MM-DD  # Sync a specific date
+./timetrap_jira_sync.sh -s -i <ID>   # Sync a single entry by tiempo ID
+./timetrap_jira_sync.sh -y           # Non-interactive (skip unparseable entries)
+./timetrap_jira_sync.sh -f           # Force re-sync already-synced entries
+./timetrap_jira_sync.sh -v           # Verbose logging
+
+# Confluence download
+./confluence-to-md.sh <PAGE_ID> [output.md]
+```
+
+## Architecture
+
+### timetrap_jira_sync.sh
+
+**Data flow:** tiempo-rs → JSON → parse → Jira CLI → SQLite
+
+1. Calls `t d --start DATE --end DATE --format=json` to get time entries as JSON
+2. Parses each entry's `note` field for the pattern `@XXX-123: Description`
+3. Calculates duration from `start`/`end` ISO timestamps
+4. Calls `jira issue worklog add <TICKET> <DURATION> --comment=... --started=...`
+5. Records synced entry IDs in SQLite at `~/.timetrap_jira_sync.db`
+
+**Duplicate prevention:** The `synced_entries` table (keyed by tiempo entry ID) prevents re-syncing. The `-f` flag bypasses this check.
+
+**Two sync modes:**
+- Batch mode (`get_todays_entries` + `sync_entries`): processes all entries for a date
+- Single mode (`get_single_entry` + `sync_single_entry`): fetches **all** entries (no date filter) then filters by ID client-side; `sync_single_entry` returns exit code 2 (not 1) when an entry is already synced, so callers can distinguish "already done" from "error"
+
+**Cross-platform date handling:** The scripts detect `gdate` (macOS with GNU coreutils), GNU `date` (Linux), and BSD `date` (macOS default) and branch accordingly for date arithmetic and formatting.
+
+### confluence-to-md.sh
+
+Reads credentials from the jira-cli config at `~/.config/.jira/.config.yml` (for `login` and `server`) using plain `grep`/`sed` (no yq/python3 needed) and the `JIRA_API_TOKEN` environment variable. Fetches the Confluence REST API (`/wiki/rest/api/content/<PAGE_ID>?expand=body.view,title`) and converts the HTML response to GitHub-flavored Markdown using `pandoc --from html --to gfm-raw_html --wrap none --strip-comments`.
+
+## Dependencies
+
+- `t` (tiempo-rs) — time tracker
+- `jira` (jira-cli) — must be configured via `jira init`
+- `jq` — JSON parsing
+- `sqlite3` — sync state tracking
+- `pandoc` — HTML-to-Markdown conversion (confluence-to-md.sh only)
+- `curl` — HTTP requests (confluence-to-md.sh only)
+
+## Time entry format
+
+Entries must be noted in tiempo-rs as:
+```
+@XXX-123: Description/notes
+```
+Entries not matching this format trigger an interactive prompt (or are skipped with `-y`).

--- a/README.md
+++ b/README.md
@@ -93,6 +93,36 @@ If an entry doesn't follow this format, you'll be prompted to enter a Jira issue
 ./timetrap_jira_sync.sh -f
 ```
 
+## Confluence to Markdown
+
+`confluence-to-md.sh` downloads a Confluence page and converts it to GitHub-flavored Markdown.
+
+### Requirements
+
+- curl
+- jq
+- pandoc
+- jira-cli configured (reuses `~/.config/.jira/.config.yml` for server and login)
+- `JIRA_API_TOKEN` environment variable set
+
+### Usage
+
+```bash
+./confluence-to-md.sh <PAGE_ID> [output.md]
+```
+
+The output file defaults to `confluence-<PAGE_ID>.md` if not specified.
+
+### Examples
+
+```bash
+# Download page to confluence-123456789.md
+./confluence-to-md.sh 123456789
+
+# Download page to a specific file
+./confluence-to-md.sh 123456789 my-page.md
+```
+
 ## Troubleshooting
 
 - If you get errors about invalid JSON, make sure your tiempo-rs installation is working correctly

--- a/confluence-to-md.sh
+++ b/confluence-to-md.sh
@@ -7,7 +7,7 @@
 # Usage:
 #   ./confluence-to-md.sh <PAGE_ID> [output.md]
 #
-# Dependencies: curl, jq, pandoc, python3 (for yq fallback) or yq
+# Dependencies: curl, jq, pandoc
 #
 # Examples:
 #   ./confluence-to-md.sh 123456789
@@ -70,9 +70,10 @@ API_URL="${CONFLUENCE_BASE}/wiki/rest/api/content/${PAGE_ID}?expand=body.view,ti
 echo "Fetching page ${PAGE_ID} from ${CONFLUENCE_BASE}..."
 
 RESPONSE=$(curl --silent --fail \
-  --user "${LOGIN}:${TOKEN}" \
+  --config - \
   --header "Accept: application/json" \
-  "$API_URL") || die "Failed to fetch page. Check the PAGE_ID and your credentials."
+  "$API_URL" \
+  <<< "user = \"${LOGIN}:${TOKEN}\"") || die "Failed to fetch page. Check the PAGE_ID and your credentials."
 
 TITLE=$(echo "$RESPONSE" | jq -r '.title // "Untitled"')
 HTML=$(echo "$RESPONSE" | jq -r '.body.view.value')

--- a/confluence-to-md.sh
+++ b/confluence-to-md.sh
@@ -91,7 +91,7 @@ trap 'rm -f "$TMPFILE"' EXIT
   printf "# %s\n\n" "$TITLE"
   echo "$HTML" | pandoc \
     --from html \
-    --to gfm+raw_html \
+    --to gfm-raw_html \
     --wrap none \
     --strip-comments
 } > "$TMPFILE"

--- a/confluence-to-md.sh
+++ b/confluence-to-md.sh
@@ -30,7 +30,7 @@ require() {
 # Read a key from the jira-cli YAML config (no yq needed)
 read_config() {
   local key="$1"
-  grep -m1 "^${key}:" "$JIRA_CONFIG" 2>/dev/null | sed "s/^${key}:[[:space:]]*//" | tr -d "'\""
+  grep -m1 "^${key}:" "$JIRA_CONFIG" 2>/dev/null | sed "s/^${key}:[[:space:]]*//" | tr -d "'\"" || true
 }
 
 # ── Validate dependencies ─────────────────────────────────────────────────────
@@ -84,13 +84,17 @@ HTML=$(echo "$RESPONSE" | jq -r '.body.view.value')
 
 echo "Converting to Markdown..."
 
+TMPFILE=$(mktemp)
+trap 'rm -f "$TMPFILE"' EXIT
+
 {
   printf "# %s\n\n" "$TITLE"
   echo "$HTML" | pandoc \
     --from html \
-    --to gfm-raw_html \
+    --to gfm+raw_html \
     --wrap none \
     --strip-comments
-} > "$OUTPUT"
+} > "$TMPFILE"
 
+mv "$TMPFILE" "$OUTPUT"
 echo "Saved: $OUTPUT"

--- a/confluence-to-md.sh
+++ b/confluence-to-md.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# confluence-to-md.sh — Download a Confluence page as Markdown
+#
+# Reads credentials from the jira-cli config (~/.config/.jira/.config.yml)
+# and the JIRA_API_TOKEN environment variable.
+#
+# Usage:
+#   ./confluence-to-md.sh <PAGE_ID> [output.md]
+#
+# Dependencies: curl, jq, pandoc, python3 (for yq fallback) or yq
+#
+# Examples:
+#   ./confluence-to-md.sh 123456789
+#   ./confluence-to-md.sh 123456789 my-page.md
+
+set -euo pipefail
+
+JIRA_CONFIG="${HOME}/.config/.jira/.config.yml"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+require() {
+  for cmd in "$@"; do
+    command -v "$cmd" &>/dev/null || die "'$cmd' is required but not installed."
+  done
+}
+
+# Read a key from the jira-cli YAML config (no yq needed)
+read_config() {
+  local key="$1"
+  grep -m1 "^${key}:" "$JIRA_CONFIG" 2>/dev/null | sed "s/^${key}:[[:space:]]*//" | tr -d "'\""
+}
+
+# ── Validate dependencies ─────────────────────────────────────────────────────
+
+require curl jq pandoc
+
+# ── Load credentials ──────────────────────────────────────────────────────────
+
+[[ -f "$JIRA_CONFIG" ]] || die "jira-cli config not found at $JIRA_CONFIG. Run 'jira init' first."
+
+TOKEN="${JIRA_API_TOKEN:-}"
+[[ -n "$TOKEN" ]] || die "JIRA_API_TOKEN is not set. Add it to your shell profile."
+
+LOGIN="$(read_config login)"
+SERVER="$(read_config server)"
+
+[[ -n "$LOGIN" ]] || die "Could not read 'login' from $JIRA_CONFIG"
+[[ -n "$SERVER" ]] || die "Could not read 'server' from $JIRA_CONFIG"
+
+# Confluence lives on the same host as Jira
+CONFLUENCE_BASE="$SERVER"
+
+# ── Arguments ─────────────────────────────────────────────────────────────────
+
+[[ $# -ge 1 ]] || {
+  echo "Usage: $(basename "$0") <PAGE_ID> [output.md]"
+  exit 1
+}
+
+PAGE_ID="$1"
+OUTPUT="${2:-confluence-${PAGE_ID}.md}"
+
+# ── Fetch page ────────────────────────────────────────────────────────────────
+
+API_URL="${CONFLUENCE_BASE}/wiki/rest/api/content/${PAGE_ID}?expand=body.view,title"
+
+echo "Fetching page ${PAGE_ID} from ${CONFLUENCE_BASE}..."
+
+RESPONSE=$(curl --silent --fail \
+  --user "${LOGIN}:${TOKEN}" \
+  --header "Accept: application/json" \
+  "$API_URL") || die "Failed to fetch page. Check the PAGE_ID and your credentials."
+
+TITLE=$(echo "$RESPONSE" | jq -r '.title // "Untitled"')
+HTML=$(echo "$RESPONSE" | jq -r '.body.view.value')
+
+[[ -n "$HTML" && "$HTML" != "null" ]] || die "Page returned empty content."
+
+# ── Convert to Markdown ───────────────────────────────────────────────────────
+
+echo "Converting to Markdown..."
+
+{
+  printf "# %s\n\n" "$TITLE"
+  echo "$HTML" | pandoc \
+    --from html \
+    --to gfm-raw_html \
+    --wrap none \
+    --strip-comments
+} > "$OUTPUT"
+
+echo "Saved: $OUTPUT"


### PR DESCRIPTION
This pull request introduces a new script for downloading and converting Confluence pages to Markdown, along with documentation improvements to help users understand and use the scripts in this repository.

**New functionality and documentation:**

*Added Confluence-to-Markdown support:*

- Introduced the `confluence-to-md.sh` script, which downloads a Confluence page using credentials from the existing Jira CLI config and converts it to GitHub-flavored Markdown using `pandoc`. The script includes robust error handling, dependency checks, and clear usage instructions.

- Updated `README.md` with a new section describing the Confluence-to-Markdown workflow, requirements, usage, and examples for the new script.

*Documentation and guidance improvements:*

- Added a new `CLAUDE.md` file that provides detailed guidance for contributors (and Claude Code) on the scripts in this repository, including their purpose, architecture, dependencies, and time entry formats. This helps onboard new developers and clarifies expected workflows.